### PR TITLE
Update branch name in GitHub workflow

### DIFF
--- a/.github/workflows/hugo-site-build.yml
+++ b/.github/workflows/hugo-site-build.yml
@@ -5,7 +5,7 @@ on:
   # Runs on pushes targeting the default branch
   push:
     branches:
-      - main
+      - release
     paths:
       - 'docs/**'
 


### PR DESCRIPTION
This commit updates the branch name in the GitHub workflow file from "main" to "release". This change ensures that the workflow runs on pushes targeting the "release" branch and includes changes made to the "docs" directory.